### PR TITLE
Fixed batch processing using the wrong polynomials for creating tonic data

### DIFF
--- a/analyze/deconvolution/deconv_optimize.m
+++ b/analyze/deconvolution/deconv_optimize.m
@@ -1,5 +1,7 @@
 function [xopt, opthistory] = deconv_optimize(x0, nr_iv, method)
 
+global leda2 % for tonic driver history
+
 if nr_iv == 0
     xopt = x0;
     opthistory = [];
@@ -22,6 +24,7 @@ for i = 1: min(nr_iv, length(xList))
     else
         [x, history] = cgd(xList{i}, @sdeconv_analysis, [.3 2], .01, 20, .05);
     end
+    tonicDriver_poly_history(i) = leda2.analysis0.target.poly; % tonicDriver's polynomials needs to match
     opthistory(i) = history;
     x_opt(i) = {x};
     err_opt(i) = history.error(end);
@@ -30,5 +33,6 @@ end
 
 [mn, idx] = min(err_opt);
 
+leda2.analysis0.target.poly = tonicDriver_poly_history(idx); % tonicDriver's polynomials needs to match
 xopt = x_opt{idx};
 add2log(0, ['Final optimized parameter: ',sprintf(' %5.2f\t',xopt),sprintf(' Error: %6.3f',mn)], 0,1,1,1,0)

--- a/analyze/deconvolution/sdeco.m
+++ b/analyze/deconvolution/sdeco.m
@@ -223,7 +223,7 @@ leda2.analysis0.target.t = leda2.data.time.data;
 leda2.analysis0.target.d = leda2.data.conductance.data;
 leda2.analysis0.target.sr = leda2.data.samplingrate;
 
-sdeconv_analysis(leda2.analysis0.tau, 1); %fix until tonicDriver is read from leda2.analysis0.target.poly of the best optimization
+sdeconv_analysis(leda2.analysis0.tau, 0); % Only a very hacky fix - prnthp 1/12/2018
 
 delete_fit(0);
 leda2.analysis0 = rmfield(leda2.analysis0, {'target','driverSC'});

--- a/analyze/deconvolution/sdeco.m
+++ b/analyze/deconvolution/sdeco.m
@@ -72,39 +72,39 @@ if ~leda2.intern.batchmode
     %     if exist('leda2.gui.deconv.fig') && ishandle(leda2.gui.deconv.fig)
     %         close(leda2.gui.deconv.fig)
     %     end
-    
+
     leda2.gui.deconv.fig = figure('Units','normalized','Position',[.1 .05 .8 .9],'Name','Continuous Decomposition Analysis','Color',leda2.gui.col.fig,'ToolBar','figure','NumberTitle','off','MenuBar','none');  %
-    
+
     leda2.gui.deconv.text_tau1 = uicontrol('Style','text','Units','normalized','Position',[.1 .01 .05 .02],'String','tau1','BackgroundColor',get(gcf,'Color'));
     leda2.gui.deconv.text_tau2 = uicontrol('Style','text','Units','normalized','Position',[.18 .01 .05 .02],'String','tau2','BackgroundColor',get(gcf,'Color'));
     %leda2.gui.deconv.text_dist0 = uicontrol('Style','text','Units','normalized','Position',[.26 .01 .05 .02],'String','dist0','BackgroundColor',get(gcf,'Color'));
     leda2.gui.deconv.edit_tau1 = uicontrol('Style','edit','Units','normalized','Position',[.1 .04 .05 .03],'String',leda2.analysis0.tau(1));  %tmp_tau1
     leda2.gui.deconv.edit_tau2 = uicontrol('Style','edit','Units','normalized','Position',[.18 .04 .05 .03],'String',leda2.analysis0.tau(2));  %tmp_tau2
     %leda2.gui.deconv.edit_dist0 = uicontrol('Style','edit','Units','normalized','Position',[.26 .04 .05 .03],'String',leda2.analysis0.dist0);  %tmp_dist0
-    
+
     leda2.gui.deconv.text_smoothWinSize = uicontrol('Style','text','Units','normalized','Position',[.31 .065 .08 .025],'String','Smooth-Win [sec]  (SD of Gauss)','BackgroundColor',get(gcf,'Color'));
     leda2.gui.deconv.text_gridsize = uicontrol('Style','text','Units','normalized','Position',[.34 .035 .05 .02],'String','Grid-Size','BackgroundColor',get(gcf,'Color'));
     leda2.gui.deconv.text_sigPeak = uicontrol('Style','text','Units','normalized','Position',[.34 .005 .05 .02],'String','Sig-Peak','BackgroundColor',get(gcf,'Color'));
     leda2.gui.deconv.edit_smoothWinSize = uicontrol('Style','edit','Units','normalized','Position',[.4 .07 .05 .02],'String',leda2.analysis0.smoothwin);
     leda2.gui.deconv.edit_gridSize = uicontrol('Style','edit','Units','normalized','Position',[.4 .04 .05 .02],'String',leda2.set.tonicGridSize_sdeco);
     leda2.gui.deconv.edit_sigPeak = uicontrol('Style','edit','Units','normalized','Position',[.4 .01 .05 .02],'String',leda2.set.sigPeak);
-    
+
     %leda2.gui.deconv.chbx_d0Autoupdate = uicontrol('Style','checkbox','Units','normalized','Position',[.48 .07 .09 .02],'String','d0 autopdate','Value',leda2.set.d0Autoupdate,'BackgroundColor',get(gcf,'Color'));  %tmp_tau1
     leda2.gui.deconv.chbx_tonicIsConst = uicontrol('Style','checkbox','Units','normalized','Position',[.48 .04 .09 .02],'String','tonic = const','Value',leda2.set.tonicIsConst,'BackgroundColor',get(gcf,'Color'),'Enable','Off');  %tmp_tau1
     leda2.gui.deconv.chbx_tonicSlowIncrease = uicontrol('Style','checkbox','Units','normalized','Position',[.48 .01 .09 .02],'String','tonic slow increase','Value',leda2.set.tonicSlowIncrease,'BackgroundColor',get(gcf,'Color'),'Enable','Off');  %tmp_tau1
-    
+
     leda2.gui.deconv.butt_analyze = uicontrol('Style','pushbutton','Units','normalized','Position',[.6 .05 .1 .03],'String','Analyze','Callback',@deconv_analysis_gui);
     leda2.gui.deconv.butt_optimize = uicontrol('Style','pushbutton','Units','normalized','Position',[.6 .02 .1 .02],'String','Optimize','Callback',@deconv_opt);
     leda2.gui.deconv.butt_apply = uicontrol('Style','pushbutton','Units','normalized','Position',[.75 .03 .15 .05],'String','Apply','Callback',@deconv_apply);
-    
+
     deconv_analysis_gui;
-    
+
 else
-    
+
     [err, x] = sdeconv_analysis(leda2.analysis0.tau);  %set dist0
     [leda2.analysis0.tau, leda2.analysis0.opt_history] = deconv_optimize(x, nr_iv,'sdeco');
     deconv_apply;
-    
+
 end
 
 
@@ -223,7 +223,7 @@ leda2.analysis0.target.t = leda2.data.time.data;
 leda2.analysis0.target.d = leda2.data.conductance.data;
 leda2.analysis0.target.sr = leda2.data.samplingrate;
 
-sdeconv_analysis(leda2.analysis0.tau, 0);
+sdeconv_analysis(leda2.analysis0.tau, 1); %fix until tonicDriver is read from leda2.analysis0.target.poly of the best optimization
 
 delete_fit(0);
 leda2.analysis0 = rmfield(leda2.analysis0, {'target','driverSC'});


### PR DESCRIPTION
When batch mode processing is ran, the tonic data is generated from polynomials from the optimization instead of the best one. This simply stores a history of polynomials and uses the best one. (same index as [mn, idx] = min(err_opt))

**This is a major, major bug.** Any SCRs processed with batch mode should be wary of their results as the tonic data could have been off by a lot.