### PR TITLE
Disabled automatic downsampling, pulled PR#4 by prnthp and minor additional tweaks.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,14 @@
-Ledalab...
+Ledalab - GTRC fork
 ==========
+
+> This is a fork of the Ledalab project by Balázs Knakker with bugfixes.
+> **Please note that I am not a maintainer of this project (and apparently noone is).**
+
+It incorporates a fix of this issue: https://github.com/ledalab/ledalab/pull/4
+by prnthp (https://github.com/prnthp/ledalab).
+I also disabled automatic downsampling in the CDA analysis. 
+Here, long data could trigger automatic downsampling without any protection against
+aliasing.
 
 - is a Matlab-based software for the analysis of skin conductance data (SC; i.e., EDA, GSR).
 - can import various file formats (including BioPac, Biotrace, CassyLab, PortiLab, PsychLab, VarioPort, VisionAnalyzer, VitaPort) and provides many preprocessing functions.

--- a/analyze/deconvolution/deconv_optimize.m
+++ b/analyze/deconvolution/deconv_optimize.m
@@ -1,5 +1,7 @@
 function [xopt, opthistory] = deconv_optimize(x0, nr_iv, method)
 
+global leda2 % for tonic driver history
+
 if nr_iv == 0
     xopt = x0;
     opthistory = [];
@@ -22,6 +24,7 @@ for i = 1: min(nr_iv, length(xList))
     else
         [x, history] = cgd(xList{i}, @sdeconv_analysis, [.3 2], .01, 20, .05);
     end
+    tonicDriver_poly_history(i) = leda2.analysis0.target.poly; % tonicDriver's polynomials needs to match
     opthistory(i) = history;
     x_opt(i) = {x};
     err_opt(i) = history.error(end);
@@ -30,5 +33,6 @@ end
 
 [mn, idx] = min(err_opt);
 
+leda2.analysis0.target.poly = tonicDriver_poly_history(idx); % tonicDriver's polynomials needs to match
 xopt = x_opt{idx};
 add2log(0, ['Final optimized parameter: ',sprintf(' %5.2f\t',xopt),sprintf(' Error: %6.3f',mn)], 0,1,1,1,0)

--- a/analyze/deconvolution/sdeco.m
+++ b/analyze/deconvolution/sdeco.m
@@ -14,13 +14,13 @@ leda2.set.segmWidth = 12;
 leda2.analysis0 = [];
 
 %Downsample data for preanalysis, downsample if N > N_max but keep
-%samplingrate at 4 Hz minimum
+%samplingrate at 20 Hz minimum
 leda2.analysis0.target.t = leda2.data.time.data;
 leda2.analysis0.target.d = leda2.data.conductance.data;
 leda2.analysis0.target.sr = leda2.data.samplingrate;
 
-Fs_min = 4;
-N_max = 3000;
+Fs_min = 20;
+N_max = 15000;
 Fs = round(leda2.data.samplingrate);
 N = leda2.data.N;
 
@@ -43,6 +43,7 @@ if N > N_max
         leda2.analysis0.target.t = td;
         leda2.analysis0.target.d = scd;
         leda2.analysis0.target.sr = FsL(idx);
+        warning('Data downsampled to %u Hz, assuming no aliasing!',FsL(idx));
     else
         %can not be downsampled any further
     end

--- a/analyze/deconvolution/sdeco.m
+++ b/analyze/deconvolution/sdeco.m
@@ -24,7 +24,7 @@ N_max = 15000;
 Fs = round(leda2.data.samplingrate);
 N = leda2.data.N;
 
-if N > N_max
+if false && N > N_max % I turned of automatic downsampling.
     factorL = divisors(Fs);
     FsL = Fs./ factorL;
     idx = find(FsL >= Fs_min);

--- a/analyze/deconvolution/sdeco.m
+++ b/analyze/deconvolution/sdeco.m
@@ -223,7 +223,7 @@ leda2.analysis0.target.t = leda2.data.time.data;
 leda2.analysis0.target.d = leda2.data.conductance.data;
 leda2.analysis0.target.sr = leda2.data.samplingrate;
 
-sdeconv_analysis(leda2.analysis0.tau, 1); %fix until tonicDriver is read from leda2.analysis0.target.poly of the best optimization
+sdeconv_analysis(leda2.analysis0.tau, 0); % Only a very hacky fix - prnthp 1/12/2018
 
 delete_fit(0);
 leda2.analysis0 = rmfield(leda2.analysis0, {'target','driverSC'});

--- a/analyze/deconvolution/sdeco.m
+++ b/analyze/deconvolution/sdeco.m
@@ -72,39 +72,39 @@ if ~leda2.intern.batchmode
     %     if exist('leda2.gui.deconv.fig') && ishandle(leda2.gui.deconv.fig)
     %         close(leda2.gui.deconv.fig)
     %     end
-    
+
     leda2.gui.deconv.fig = figure('Units','normalized','Position',[.1 .05 .8 .9],'Name','Continuous Decomposition Analysis','Color',leda2.gui.col.fig,'ToolBar','figure','NumberTitle','off','MenuBar','none');  %
-    
+
     leda2.gui.deconv.text_tau1 = uicontrol('Style','text','Units','normalized','Position',[.1 .01 .05 .02],'String','tau1','BackgroundColor',get(gcf,'Color'));
     leda2.gui.deconv.text_tau2 = uicontrol('Style','text','Units','normalized','Position',[.18 .01 .05 .02],'String','tau2','BackgroundColor',get(gcf,'Color'));
     %leda2.gui.deconv.text_dist0 = uicontrol('Style','text','Units','normalized','Position',[.26 .01 .05 .02],'String','dist0','BackgroundColor',get(gcf,'Color'));
     leda2.gui.deconv.edit_tau1 = uicontrol('Style','edit','Units','normalized','Position',[.1 .04 .05 .03],'String',leda2.analysis0.tau(1));  %tmp_tau1
     leda2.gui.deconv.edit_tau2 = uicontrol('Style','edit','Units','normalized','Position',[.18 .04 .05 .03],'String',leda2.analysis0.tau(2));  %tmp_tau2
     %leda2.gui.deconv.edit_dist0 = uicontrol('Style','edit','Units','normalized','Position',[.26 .04 .05 .03],'String',leda2.analysis0.dist0);  %tmp_dist0
-    
+
     leda2.gui.deconv.text_smoothWinSize = uicontrol('Style','text','Units','normalized','Position',[.31 .065 .08 .025],'String','Smooth-Win [sec]  (SD of Gauss)','BackgroundColor',get(gcf,'Color'));
     leda2.gui.deconv.text_gridsize = uicontrol('Style','text','Units','normalized','Position',[.34 .035 .05 .02],'String','Grid-Size','BackgroundColor',get(gcf,'Color'));
     leda2.gui.deconv.text_sigPeak = uicontrol('Style','text','Units','normalized','Position',[.34 .005 .05 .02],'String','Sig-Peak','BackgroundColor',get(gcf,'Color'));
     leda2.gui.deconv.edit_smoothWinSize = uicontrol('Style','edit','Units','normalized','Position',[.4 .07 .05 .02],'String',leda2.analysis0.smoothwin);
     leda2.gui.deconv.edit_gridSize = uicontrol('Style','edit','Units','normalized','Position',[.4 .04 .05 .02],'String',leda2.set.tonicGridSize_sdeco);
     leda2.gui.deconv.edit_sigPeak = uicontrol('Style','edit','Units','normalized','Position',[.4 .01 .05 .02],'String',leda2.set.sigPeak);
-    
+
     %leda2.gui.deconv.chbx_d0Autoupdate = uicontrol('Style','checkbox','Units','normalized','Position',[.48 .07 .09 .02],'String','d0 autopdate','Value',leda2.set.d0Autoupdate,'BackgroundColor',get(gcf,'Color'));  %tmp_tau1
     leda2.gui.deconv.chbx_tonicIsConst = uicontrol('Style','checkbox','Units','normalized','Position',[.48 .04 .09 .02],'String','tonic = const','Value',leda2.set.tonicIsConst,'BackgroundColor',get(gcf,'Color'),'Enable','Off');  %tmp_tau1
     leda2.gui.deconv.chbx_tonicSlowIncrease = uicontrol('Style','checkbox','Units','normalized','Position',[.48 .01 .09 .02],'String','tonic slow increase','Value',leda2.set.tonicSlowIncrease,'BackgroundColor',get(gcf,'Color'),'Enable','Off');  %tmp_tau1
-    
+
     leda2.gui.deconv.butt_analyze = uicontrol('Style','pushbutton','Units','normalized','Position',[.6 .05 .1 .03],'String','Analyze','Callback',@deconv_analysis_gui);
     leda2.gui.deconv.butt_optimize = uicontrol('Style','pushbutton','Units','normalized','Position',[.6 .02 .1 .02],'String','Optimize','Callback',@deconv_opt);
     leda2.gui.deconv.butt_apply = uicontrol('Style','pushbutton','Units','normalized','Position',[.75 .03 .15 .05],'String','Apply','Callback',@deconv_apply);
-    
+
     deconv_analysis_gui;
-    
+
 else
-    
+
     [err, x] = sdeconv_analysis(leda2.analysis0.tau);  %set dist0
     [leda2.analysis0.tau, leda2.analysis0.opt_history] = deconv_optimize(x, nr_iv,'sdeco');
     deconv_apply;
-    
+
 end
 
 
@@ -223,7 +223,7 @@ leda2.analysis0.target.t = leda2.data.time.data;
 leda2.analysis0.target.d = leda2.data.conductance.data;
 leda2.analysis0.target.sr = leda2.data.samplingrate;
 
-sdeconv_analysis(leda2.analysis0.tau, 0);
+sdeconv_analysis(leda2.analysis0.tau, 1); %fix until tonicDriver is read from leda2.analysis0.target.poly of the best optimization
 
 delete_fit(0);
 leda2.analysis0 = rmfield(leda2.analysis0, {'target','driverSC'});

--- a/main/save_ledafile.m
+++ b/main/save_ledafile.m
@@ -7,7 +7,7 @@ end
 if ~leda2.file.open
     return
 end
-leda2.file.filename = [leda2.file.filename(1:end-4),'.mat'];
+leda2.file.filename = [leda2.file.filename(1:end-4),'_proc.mat'];
 
 if save_as
     [filename, pathname] = uiputfile([leda2.file.filename], 'Save file as ..');


### PR DESCRIPTION
The function doing the CDA automatically downsampled large data without any antialiasing filter. If filtering was done before the CDA, which is usually the case, this can turn out OK, but can possibly lead to aliasing e.g. when working with large files. I completely turned off this downsampling and encourage users to take care about downsampling before the CDA analysis (e.g. I go down to 20Hz after an 5 Hz LP filter, should be OK.) Note that you could turn the auto downsampling back on in sdeco.m at line 27, I also adjusted the minimal Fs perimissible in the code..

I also added a suffix to output .mat filenames to prevent overwriting of source .mat files.

I also pulled this https://github.com/ledalab/ledalab/pull/4 quite important bugfix from https://github.com/prnthp/ledalab, kudos!

Note that I'm not doing a PR because I think my version is "authoritatively" preferred and/or maintained (I don't think it will be pulled), I'm just doing this to potentially aid future users. So still use this at your own risk, there might be more bugs. Given these bugs I think it is important to very well specify which version of the software was used in a paper.